### PR TITLE
Update Codacy configuration and add Codacy badge to README

### DIFF
--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -18,4 +18,4 @@ jobs:
       run: |
         bash <(curl -Ls https://coverage.codacy.com/get.sh)
       env:
-        CODECOV_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}  
+        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}  

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ![GitHub issues](https://img.shields.io/github/issues/merca/data-and-stuff)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/merca/data-and-stuff)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/64f70747a98f4a36bc5cbe5ff7fde4ad)](https://app.codacy.com/gh/merca/data-and-stuff/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 </div>
 
@@ -35,16 +36,13 @@
 
 ## 🧐 About
 
-
 In this repository, you'll find the relics of my expeditions into the uncharted territories of data engineering, architecture, analysis, and science.
-
 
 ## 🏁 Getting Started
 
 To embark upon this quest, ensure your steed (your machine) is equipped with the necessary armaments.
 
 ### Prerequisites
-
 
 Infrastructure is written with Pulumi, so you'll need to install it.
 


### PR DESCRIPTION
The commit updates the Codacy configuration file by replacing `CODECOV_TOKEN` with `CODACY_PROJECT_TOKEN`. Additionally, it adds a Codacy badge to the README file.