### PR TITLE
Add dotnet tests and publish test results 

### DIFF
--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -14,8 +14,24 @@ jobs:
         checks: write
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+          dotnet-version: 8.0.x
+    - name: Run dotnet tests
+      run: |
+        # Run your tests here
+        dotnet test ./src --collect:"XPlat Code Coverage" --logger:"trx;LogFilePrefix=testResults;verbosity=detailed" --results-directory ./test-results
+        mv -v ./test-results/*/*.* ./test-results/
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      id: test-results
+      if: always()
+      with:
+        files: |
+            test-results/**/*.trx
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload coverage reports to Codacy
       run: |
-        bash <(curl -Ls https://coverage.codacy.com/get.sh)
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ./test-results/coverage.cobertura.xml
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}  

--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -18,4 +18,4 @@ jobs:
       run: |
         bash <(curl -Ls https://coverage.codacy.com/get.sh)
       env:
-        CODECOV_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}  
+        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}  

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ![GitHub issues](https://img.shields.io/github/issues/merca/data-and-stuff)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/merca/data-and-stuff)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/64f70747a98f4a36bc5cbe5ff7fde4ad)](https://app.codacy.com/gh/merca/data-and-stuff/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 </div>
 
@@ -35,16 +36,13 @@
 
 ## 🧐 About
 
-
 In this repository, you'll find the relics of my expeditions into the uncharted territories of data engineering, architecture, analysis, and science.
-
 
 ## 🏁 Getting Started
 
 To embark upon this quest, ensure your steed (your machine) is equipped with the necessary armaments.
 
 ### Prerequisites
-
 
 Infrastructure is written with Pulumi, so you'll need to install it.
 


### PR DESCRIPTION
This commit adds the following changes:
- Added setup for dotnet version 8.0.x
- Implemented running dotnet tests with code coverage collection
- Published test results using EnricoMi/publish-unit-test-result-action
- Updated Codacy coverage report command to include the correct file path